### PR TITLE
Update image `appuio/alerts_exporter` to `v0.3.3`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -14,11 +14,11 @@ parameters:
       alerts_exporter:
         registry: ghcr.io
         image: appuio/alerts_exporter
-        tag: v0.3.2
+        tag: v0.3.3
       kube_rbac_proxy:
-        registry: gcr.io
-        image: kubebuilder/kube-rbac-proxy
-        tag: v0.16.0
+        registry: quay.io
+        image: brancz/kube-rbac-proxy
+        tag: v0.18.2
 
     manifests:
       repository: https://github.com/appuio/alerts_exporter

--- a/component/alerts-exporter.jsonnet
+++ b/component/alerts-exporter.jsonnet
@@ -62,7 +62,7 @@ com.Kustomization(
       newTag: image.tag,
       newName: '%(registry)s/%(image)s' % image,
     },
-    'gcr.io/kubebuilder/kube-rbac-proxy': {
+    'quay.io/brancz/kube-rbac-proxy': {
       local image = params.images.kube_rbac_proxy,
       newTag: image.tag,
       newName: '%(registry)s/%(image)s' % image,

--- a/tests/golden/defaults/alerts-exporter/alerts-exporter/apps_v1_deployment_alerts-exporter.yaml
+++ b/tests/golden/defaults/alerts-exporter/alerts-exporter/apps_v1_deployment_alerts-exporter.yaml
@@ -34,7 +34,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
-        image: ghcr.io/appuio/alerts_exporter:v0.3.2
+        image: ghcr.io/appuio/alerts_exporter:v0.3.3
         livenessProbe:
           httpGet:
             path: /healthz
@@ -63,7 +63,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.2
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/tests/golden/openshift4/alerts-exporter/alerts-exporter/apps_v1_deployment_alerts-exporter.yaml
+++ b/tests/golden/openshift4/alerts-exporter/alerts-exporter/apps_v1_deployment_alerts-exporter.yaml
@@ -38,7 +38,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.podIP
-        image: ghcr.io/appuio/alerts_exporter:v0.3.2
+        image: ghcr.io/appuio/alerts_exporter:v0.3.3
         livenessProbe:
           httpGet:
             path: /healthz
@@ -68,7 +68,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.16.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.18.2
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443


### PR DESCRIPTION
Also switches `kube-rbac-proxy` image to `quay.io`

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
